### PR TITLE
Refactor: updated service names to be readable

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@main
         with:
-          deno-version: "~1.9" 
+          deno-version: "1.9.1" 
 
       - name: Cache Dependencies
         run: deno cache --unstable deps.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.9.0
+FROM hayd/alpine-deno:1.9.1
 
 EXPOSE 3002
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:1.9.1
+FROM hayd/alpine-deno:1.9.2
 
 EXPOSE 3002
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ microservices and static website projects.
      <img alt="GitHub license" src="https://img.shields.io/github/license/pmprosociety/authcompanion" />
    </a>
    <a href="https://deno.land">
-     <img src="https://img.shields.io/badge/deno-1.9.1-green?logo=deno"/>
+     <img src="https://img.shields.io/badge/deno-1.9.2-green?logo=deno"/>
    </a>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ microservices and static website projects.
      <img alt="GitHub license" src="https://img.shields.io/github/license/pmprosociety/authcompanion" />
    </a>
    <a href="https://deno.land">
-     <img src="https://img.shields.io/badge/deno-1.9.0-green?logo=deno"/>
+     <img src="https://img.shields.io/badge/deno-1.9.1-green?logo=deno"/>
    </a>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 <h2 align="center">AuthCompanion</h2>
 
-<p align="center"> An effortless, open source, token-based user management server - well suited for
-microservices and static website projects.
+<p align="center"> An effortless, open source, token-based user management server - well suited for modern web projects.
 </p>
 
 <div align="center">

--- a/deps.ts
+++ b/deps.ts
@@ -3,8 +3,8 @@ export {
   isHttpError,
   Router,
   Status,
-} from "https://deno.land/x/oak@v7.2.0/mod.ts";
-export { Client, Pool } from "https://deno.land/x/postgres@v0.11.0/mod.ts";
+} from "https://deno.land/x/oak@v7.3.0/mod.ts";
+export { Client, Pool } from "https://deno.land/x/postgres@v0.11.1/mod.ts";
 export { compare, hash } from "https://deno.land/x/bcrypt@v0.2.4/mod.ts";
 export {
   create,
@@ -13,15 +13,15 @@ export {
   verify,
 } from "https://deno.land/x/djwt@v2.1/mod.ts";
 export type { Header, Payload } from "https://deno.land/x/djwt@v2.1/mod.ts";
-export { v4 } from "https://deno.land/std@0.92.0/uuid/mod.ts";
-export * as log from "https://deno.land/std@0.92.0/log/mod.ts";
+export { v4 } from "https://deno.land/std@0.94.0/uuid/mod.ts";
+export * as log from "https://deno.land/std@0.94.0/log/mod.ts";
 export { SmtpClient } from "https://deno.land/x/smtp@v0.7.0/mod.ts";
 export {
   cyan,
   green,
   red,
   yellow,
-} from "https://deno.land/std@0.92.0/fmt/colors.ts";
-export { format } from "https://deno.land/std@0.92.0/datetime/mod.ts";
+} from "https://deno.land/std@0.94.0/fmt/colors.ts";
+export { format } from "https://deno.land/std@0.94.0/datetime/mod.ts";
 import * as superstruct from "https://cdn.skypack.dev/superstruct";
 export { superstruct };

--- a/deps.ts
+++ b/deps.ts
@@ -4,7 +4,7 @@ export {
   Router,
   Status,
 } from "https://deno.land/x/oak@v7.3.0/mod.ts";
-export { Client, Pool } from "https://deno.land/x/postgres@v0.11.1/mod.ts";
+export { Client, Pool } from "https://deno.land/x/postgres@v0.11.2/mod.ts";
 export { compare, hash } from "https://deno.land/x/bcrypt@v0.2.4/mod.ts";
 export {
   create,

--- a/env.example
+++ b/env.example
@@ -27,6 +27,6 @@ RECOVERY_REDIRECT_URL=http://localhost:3001/recovery/
 LOGLEVEL=INFO
 LOGHANDLER=console
 
-# Cross-Origin Resource Sharing (CORS) Server Settings
+# Cross-Origin Resource Sharing (CORS) Settings
 ORIGIN=http://localhost:3001
 SECURE=false

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -1,11 +1,11 @@
 import { Router } from "../deps.ts";
-import { signIn } from "../services/signIn.ts";
+import { login } from "../services/login.ts";
 import { refresh } from "../services/refresh.ts";
-import { signUp } from "../services/signUp.ts";
-import { updateUser } from "../services/updateUser.ts";
-import { forgotPassword } from "../services/forgotPassword.ts";
+import { registration } from "../services/registration.ts";
+import { userSettings } from "../services/userSettings.ts";
+import { accountRecovery } from "../services/accountRecovery.ts";
 import { recoverToken } from "../services/recoverytoken.ts";
-import { logoutUser } from "../services/logout.ts";
+import { logout } from "../services/logout.ts";
 
 import authorize from "../middlewares/authorize.ts";
 
@@ -16,12 +16,12 @@ const router = new Router({ prefix: pathPrefix });
 
 //API Server Routes
 router
-  .post("auth/register", signUp)
-  .post("auth/login", signIn)
+  .post("auth/register", registration)
+  .post("auth/login", login)
   .post("auth/refresh", refresh)
-  .post("auth/recovery", forgotPassword)
+  .post("auth/recovery", accountRecovery)
   .post("auth/recovery/token", recoverToken)
-  .post("auth/users/me", authorize, updateUser)
-  .get("auth/logout", authorize, logoutUser);
+  .post("auth/users/me", authorize, userSettings)
+  .get("auth/logout", authorize, logout);
 
 export default router;

--- a/services/accountRecovery.ts
+++ b/services/accountRecovery.ts
@@ -21,7 +21,7 @@ const connectConfig: any = {
   password: SMTPPASSWORD,
 };
 
-export const forgotPassword = async (ctx: any) => {
+export const accountRecovery = async (ctx: any) => {
   try {
     if (!ctx.request.hasBody) {
       log.debug("Request has no body");

--- a/services/login.ts
+++ b/services/login.ts
@@ -7,7 +7,7 @@ import log from "../helpers/log.ts";
 import { superstruct } from "../deps.ts";
 import { SECURE } from "../config.ts";
 
-export const signIn = async (ctx: any) => {
+export const login = async (ctx: any) => {
   try {
     if (!ctx.request.hasBody) {
       ctx.throw(Status.BadRequest, "Bad Request, No Request Body");

--- a/services/logout.ts
+++ b/services/logout.ts
@@ -3,7 +3,7 @@ import { Status } from "../deps.ts";
 import { db } from "../db/db.ts";
 import log from "../helpers/log.ts";
 
-export const logoutUser = async (ctx: any) => {
+export const logout = async (ctx: any) => {
   try {
     const userObj = await db.queryObject({
       text: `SELECT email FROM users WHERE "UUID" = $1;`,

--- a/services/registration.ts
+++ b/services/registration.ts
@@ -7,8 +7,7 @@ import { db } from "../db/db.ts";
 import log from "../helpers/log.ts";
 import { superstruct } from "../deps.ts";
 
-// api/v1/auth/register
-export const signUp = async (ctx: any) => {
+export const registration = async (ctx: any) => {
   try {
     if (!ctx.request.hasBody) {
       log.warning("No body");

--- a/services/userSettings.ts
+++ b/services/userSettings.ts
@@ -7,7 +7,7 @@ import { db } from "../db/db.ts";
 import log from "../helpers/log.ts";
 import { superstruct } from "../deps.ts";
 
-export const updateUser = async (ctx: any) => {
+export const userSettings = async (ctx: any) => {
   try {
     if (!ctx.request.hasBody) {
       log.debug("Request has no body");

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,1 +1,1 @@
-export { Context } from "https://deno.land/x/oak@v7.2.0/mod.ts";
+export { Context } from "https://deno.land/x/oak@v7.3.0/mod.ts";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,13 +9,13 @@ import {
   makeRefreshtoken,
   validateJWT,
 } from "../helpers/jwtutils.ts";
-import { signUp } from "../services/signUp.ts";
-import { signIn } from "../services/signIn.ts";
+import { registration } from "../services/registration.ts";
+import { login } from "../services/login.ts";
 import { refresh } from "../services/refresh.ts";
-import { updateUser } from "../services/updateUser.ts";
+import { userSettings } from "../services/userSettings.ts";
 import { recoverToken } from "../services/recoverytoken.ts";
-import { logoutUser } from "../services/logout.ts";
-import { forgotPassword } from "../services/forgotPassword.ts";
+import { logout } from "../services/logout.ts";
+import { accountRecovery } from "../services/accountRecovery.ts";
 import authorize from "../middlewares/authorize.ts";
 
 const encoder = new TextEncoder();
@@ -89,7 +89,7 @@ Deno.test("API Endpoint Test: /auth/register", async () => {
     serverRequest,
   );
 
-  await signUp(ctx);
+  await registration(ctx);
 
   assertEquals(
     ctx.response.status,
@@ -114,7 +114,7 @@ Deno.test("API Endpoint Test: /auth/login", async () => {
     serverRequest,
   );
 
-  await signIn(ctx);
+  await login(ctx);
 
   assertEquals(
     ctx.response.status,
@@ -192,7 +192,7 @@ Deno.test("API Endpoint Test: /auth/users/me", async () => {
 
   ctx.state.JWTclaims = payload;
 
-  await updateUser(ctx);
+  await userSettings(ctx);
 
   assertEquals(
     ctx.response.status,
@@ -216,7 +216,7 @@ Deno.test("API Endpoint Test: /auth/users/me", async () => {
 //     serverRequest,
 //   );
 
-//   await forgotPassword(ctx);
+//   await accountRecovery(ctx);
 
 //   assertEquals(
 //     ctx.response.status,
@@ -291,7 +291,7 @@ Deno.test("API Endpoint Test: /auth/logout", async () => {
 
   ctx.state.JWTclaims = payload;
 
-  await logoutUser(ctx);
+  await logout(ctx);
 
   // Clean out the test data from the DB (helpful when running tests locally)
   await cleanTestData();


### PR DESCRIPTION
Refactored the service file names and routes to be more readable and consistent. This does not create breaking changes for the API routes. 

Waiting on a fix from postgres lib before committing to main. 

bumped deno to 1.9.1